### PR TITLE
do not change value if already present in localStorage

### DIFF
--- a/src/use-localstorage.ts
+++ b/src/use-localstorage.ts
@@ -63,7 +63,7 @@ export function useLocalStorage<TValue = string>(key: string, initialValue?: TVa
     // Write initial value to the local storage if it's not present or contains invalid JSON data.
     const storedValue = localStorage[key]
     const cantWrite = localStorage.hasOwnProperty(key) && storedValue && tryParse(storedValue) !== storedValue
-    const canWrite = !canWrite
+    const canWrite = !cantWrite
 
     if (initialValue && canWrite) {
       writeStorage(key, initialValue);

--- a/src/use-localstorage.ts
+++ b/src/use-localstorage.ts
@@ -60,8 +60,14 @@ export function useLocalStorage<TValue = string>(key: string, initialValue?: TVa
     // The storage event only works in the context of other documents (eg. other browser tabs)
     window.addEventListener('storage', e => onLocalStorageChange(e));
 
-    if (initialValue)
+    // Write initial value to the local storage if it's not present or contains invalid JSON data.
+    const storedValue = localStorage[key]
+    const cantWrite = localStorage.hasOwnProperty(key) && storedValue && tryParse(storedValue) !== storedValue
+    const canWrite = !canWrite
+
+    if (initialValue && canWrite) {
       writeStorage(key, initialValue);
+    }
 
     return () => {
       window.removeEventListener(

--- a/test/use-localstorage.test.ts
+++ b/test/use-localstorage.test.ts
@@ -8,5 +8,21 @@ describe('Module: use-localstorage', () => {
             
             expect(result.current).toBeDefined();
         });
+
+        it('does not override existing data', () => {
+            const key = `dynamickey-` + Date.now()
+            const firstDefaultValue = Date.now()
+
+            // first call of the hook
+            renderHook(() => useLocalStorage(key, firstDefaultValue));
+
+            // second render. as the value already set, default value
+            // should not override existing value.
+            const { result: result2 } = renderHook(() => useLocalStorage(key, Date()));
+
+            const [lastValue] = result2.current
+
+            expect(lastValue).toEqual(firstDefaultValue);
+        });
     });
 });


### PR DESCRIPTION
Hi, it seems `initialValue` get written to the localStorage on start. This makes using this hook to persist data impossible. Because it overrides existing data at the first `useLocalStorage` call. I've made some changes to prevent existing data to be overridden if key already presents and contains valid json data.