### PR TITLE
fix to avoid re-render

### DIFF
--- a/src/use-localstorage.ts
+++ b/src/use-localstorage.ts
@@ -80,9 +80,12 @@ export function useLocalStorage<TValue = string>(key: string, initialValue?: TVa
     };
   }, []);
 
+  const writeState = useCallback((value: TValue) => writeStorage(key, value), []);
+  const deleteState = useCallback(() => deleteFromStorage(key), []);
+
   return [
     localState === null ? initialValue : localState,
-    (value: TValue) => writeStorage(key, value),
-    () => deleteFromStorage(key)
+    writeState,
+    deleteState
   ];
 }


### PR DESCRIPTION
fix useLocalStorage functions to memorize.
the functions are changed at every rendering currently.

example
```
const [val, setVal] = useLocalStorage("key", { some: "value" });
// below code causes infinite loop.
useEffect(() => {
  // some effect
  setVal({some: xxx});
}, [setVal, foo, bar, ...]);
```

I noticed it by using [react-hooks/exhaustive-deps](https://www.npmjs.com/package/eslint-plugin-react-hooks)