### PR TITLE
Fix stale localState

### DIFF
--- a/src/use-localstorage.ts
+++ b/src/use-localstorage.ts
@@ -60,7 +60,7 @@ export function useLocalStorage<TValue = string>(
         }
       }
     },
-    [updateLocalState]
+    [updateLocalState, key]
   );
 
   useEffect(() => {

--- a/src/use-localstorage.ts
+++ b/src/use-localstorage.ts
@@ -1,4 +1,9 @@
-import { writeStorage, deleteFromStorage, LocalStorageChanged, isTypeOfLocalStorageChanged } from './local-storage-events';
+import {
+  writeStorage,
+  deleteFromStorage,
+  LocalStorageChanged,
+  isTypeOfLocalStorageChanged,
+} from './local-storage-events';
 import { useEffect, useState, Dispatch, useCallback } from 'react';
 
 function tryParse(value: string) {
@@ -24,39 +29,49 @@ function tryParse(value: string) {
  *   );
  * };
  * ```
- * 
+ *
  * @export
  * @template TValue The type of the given initial value.
  * @param {string} key The key in the localStorage that you wish to watch.
  * @param {TValue} initialValue Optional initial value to start with.
- * @returns {[TValue | null, Dispatch<TValue>, Dispatch<void>]} An array containing the value 
+ * @returns {[TValue | null, Dispatch<TValue>, Dispatch<void>]} An array containing the value
  * associated with the key in position 0, a function to set the value in position 1,
  * and a function to delete the value from localStorage in position 2.
  */
-export function useLocalStorage<TValue = string>(key: string, initialValue?: TValue): [TValue | null, Dispatch<TValue>, Dispatch<void>] {
-  const [localState, updateLocalState] = useState(tryParse(localStorage.getItem(key)!) || initialValue);
+export function useLocalStorage<TValue = string>(
+  key: string,
+  initialValue?: TValue
+): [TValue | null, Dispatch<TValue>, Dispatch<void>] {
+  const [localState, updateLocalState] = useState(
+    tryParse(localStorage.getItem(key)!) || initialValue
+  );
 
-  const onLocalStorageChange = useCallback((event: LocalStorageChanged<TValue> | StorageEvent) => {
-    if (isTypeOfLocalStorageChanged(event)) {
-      if (event.detail.key === key) {
-        updateLocalState(event.detail.value);
-      }
-    } else {
-      if (event.key === key) {
-        if (event.newValue) {
-          updateLocalState(tryParse(event.newValue));
+  const onLocalStorageChange = useCallback(
+    (event: LocalStorageChanged<TValue> | StorageEvent) => {
+      if (isTypeOfLocalStorageChanged(event)) {
+        if (event.detail.key === key) {
+          updateLocalState(event.detail.value);
+        }
+      } else {
+        if (event.key === key) {
+          if (event.newValue) {
+            updateLocalState(tryParse(event.newValue));
+          }
         }
       }
-    }
-  }, [updateLocalState]);
-
+    },
+    [updateLocalState]
+  );
 
   useEffect(() => {
-    // The custom storage event allows us to update our component 
+    updateLocalState(tryParse(localStorage.getItem(key)!) || initialValue);
+  }, [key]);
+
+  useEffect(() => {
+    // The custom storage event allows us to update our component
     // when a change occurs in localStorage outside of our component
-    window.addEventListener(
-      LocalStorageChanged.eventName,
-      (e: any) => onLocalStorageChange(e as LocalStorageChanged<TValue>)
+    window.addEventListener(LocalStorageChanged.eventName, (e: any) =>
+      onLocalStorageChange(e as LocalStorageChanged<TValue>)
     );
 
     // The storage event only works in the context of other documents (eg. other browser tabs)
@@ -72,20 +87,15 @@ export function useLocalStorage<TValue = string>(key: string, initialValue?: TVa
     }
 
     return () => {
-      window.removeEventListener(
-        LocalStorageChanged.eventName,
-        (e: any) => onLocalStorageChange(e as LocalStorageChanged<TValue>)
+      window.removeEventListener(LocalStorageChanged.eventName, (e: any) =>
+        onLocalStorageChange(e as LocalStorageChanged<TValue>)
       );
       window.removeEventListener('storage', e => onLocalStorageChange(e));
     };
-  }, []);
+  }, [key]);
 
   const writeState = useCallback((value: TValue) => writeStorage(key, value), [key]);
   const deleteState = useCallback(() => deleteFromStorage(key), [key]);
 
-  return [
-    localState === null ? initialValue : localState,
-    writeState,
-    deleteState
-  ];
+  return [localState === null ? initialValue : localState, writeState, deleteState];
 }

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -193,7 +193,7 @@ describe('Integration Tests', () => {
     const EditAge = ({ name }: { name?: string }) => {
       if (!name)
         return <></>;
-      
+
       const [age, setAge] = useLocalStorage(name, 0);
 
       return (
@@ -228,9 +228,30 @@ describe('Integration Tests', () => {
     expect(localStorage.getItem(allPeople[0])).toBe('0');
 
     const [editAgeInput] = await findAllByTestId(`${allPeople[0]}:input`);
-    fireEvent.change(editAgeInput, { target: { value: 24 }});
+    fireEvent.change(editAgeInput, { target: { value: 24 } });
 
     // The event listener that is registered from the hook should use the event above to update the storage
     expect(localStorage.getItem(allPeople[0])).toBe('24');
+  });
+
+  it('should update localState when the key changes externally', async () => {
+    const TestComponent = () => {
+      const [key, set] = React.useState('key1');
+      let [name, setName] = useLocalStorage(key, 'default value');
+      React.useEffect(() => {
+        setName('key1 name');
+        setTimeout(() => set('key2'));
+      }, []);
+
+      return (
+        <div>
+          <h1>{name}</h1>
+        </div>
+      );
+    };
+
+    const { findByText } = render(<TestComponent />);
+    expect(await findByText(/key1 name/i)).toBeDefined();
+    expect(await findByText(/default value/i)).toBeDefined();
   });
 });


### PR DESCRIPTION
I noticed that when keys dynamically change and re-render, localState is stale. The following example demonstrates this currently:

```javascript
const App = () => {
  // key starts out as one value
  const [key, set] = React.useState('key1');

  // pass in key to get localStorage
  let [name, setName] = useLocalStorage(key, 'default value');
  React.useEffect(() => {
    // immediately set localStorage value to something
    setName('key1 name');

    // update the key and re-render
    setTimeout(() => set('key2'), 1000);

    // resulted in the {name} below always printing "key1 name"
  }, []);

  return (
    <div>
      <h1>{name}</h1>
    </div>
  );
};
```

This pull request fixes this by basically adding the key as a dependency to each useEffect/useCallback, and adding an effect that rehydrates localState when the key changes with whatever the actual value is.

I also wrote a test in `test/index.test.tsx` to ensure it works. Current tests don't catch a stale `onLocalStorageChange useCallback` at the moment either - worth noting.

Finally - I apologies for the handful of formatting changes - there is no `.prettierrc` file to enforce code style.

Let me know if you have any questions! Cheers for the great plugin otherwise.