### PR TITLE
Support false values with a true fallback value

### DIFF
--- a/src/use-localstorage.ts
+++ b/src/use-localstorage.ts
@@ -14,6 +14,15 @@ function tryParse(value: string) {
   }
 }
 
+function isValidJSON(value: string) {
+  try {
+    JSON.parse(value);
+  } catch {
+    return false;
+  }
+  return true;
+}
+
 /**
  * React hook to enable updates to state via localStorage.
  * This updates when the {writeStorage} function is used, when the returned function
@@ -74,15 +83,7 @@ export function useLocalStorage<TValue = string>(
     // The storage event only works in the context of other documents (eg. other browser tabs)
     window.addEventListener('storage', listener);
 
-    // We need to check if there is a stored value
-    // and if the stored value is a boolean
-    // because local storage value should not be updated if parsed value is false but stored value is "false"
-    const storedValue = localStorage.getItem(key);
-    const canWrite = storedValue === null
-        || (
-            typeof tryParse(storedValue) !== 'boolean'
-              && tryParse(storedValue) !== storedValue
-        );
+    const canWrite = localStorage.getItem(key) === null || !isValidJSON(localStorage.getItem(key)!);
 
     // Write initial value to the local storage if it's not present or contains invalid JSON data.
     if (initialValue !== undefined && canWrite) {

--- a/src/use-localstorage.ts
+++ b/src/use-localstorage.ts
@@ -43,7 +43,7 @@ export function useLocalStorage<TValue = string>(
   initialValue?: TValue
 ): [TValue | null, Dispatch<TValue>, Dispatch<void>] {
   const [localState, updateLocalState] = useState(
-    tryParse(localStorage.getItem(key)!) || initialValue
+      localStorage.getItem(key) === null ? initialValue : tryParse(localStorage.getItem(key)!)
   );
 
   const onLocalStorageChange = (event: LocalStorageChanged<TValue> | StorageEvent) => {
@@ -62,7 +62,7 @@ export function useLocalStorage<TValue = string>(
 
   // when the key changes, update localState to reflect it.
   useEffect(() => {
-    updateLocalState(tryParse(localStorage.getItem(key)!) || initialValue);
+    updateLocalState(localStorage.getItem(key) === null ? initialValue : tryParse(localStorage.getItem(key)!));
   }, [key]);
 
   useEffect(() => {
@@ -74,9 +74,15 @@ export function useLocalStorage<TValue = string>(
     // The storage event only works in the context of other documents (eg. other browser tabs)
     window.addEventListener('storage', listener);
 
-    // We need to check if there is a stored value because we do not wish to overwrite it.
+    // We need to check if there is a stored value
+    // and if the stored value is a boolean
+    // because local storage value should not be updated if parsed value is false but stored value is "false"
     const storedValue = localStorage.getItem(key);
-    const canWrite = !(storedValue && tryParse(storedValue) !== storedValue);
+    const canWrite = storedValue === null
+        || (
+            typeof tryParse(storedValue) !== 'boolean'
+              && tryParse(storedValue) !== storedValue
+        );
 
     // Write initial value to the local storage if it's not present or contains invalid JSON data.
     if (initialValue !== undefined && canWrite) {

--- a/test/use-localstorage.test.ts
+++ b/test/use-localstorage.test.ts
@@ -1,6 +1,5 @@
 import { useLocalStorage } from '../src';
 import { renderHook } from 'react-hooks-testing-library';
-import {render} from "@testing-library/react";
 
 describe('Module: use-localstorage', () => {
     describe('useLocalStorage', () => {

--- a/test/use-localstorage.test.ts
+++ b/test/use-localstorage.test.ts
@@ -1,5 +1,6 @@
 import { useLocalStorage } from '../src';
 import { renderHook } from 'react-hooks-testing-library';
+import {render} from "@testing-library/react";
 
 describe('Module: use-localstorage', () => {
     describe('useLocalStorage', () => {
@@ -43,6 +44,32 @@ describe('Module: use-localstorage', () => {
 
             expect(result.current[0]).toBe(defaultValue);
             expect(localStorage.getItem(key)).toBe(`${defaultValue}`);
+        });
+
+        describe('when existing value is false', () => {
+            it ('returns false value when the default value is true', () => {
+                const key = 'AmIFalse';
+                const defaultValue = true;
+
+                localStorage.setItem(key, 'false');
+
+                const { result } = renderHook(() => useLocalStorage(key, defaultValue));
+
+                expect(result.current[0]).toBe(false);
+                expect(JSON.parse(localStorage.getItem(key)!)).toBe(false);
+            });
+
+            it('returns false value when default value is false', () => {
+                const key = 'AmIFalse';
+                const defaultValue = false;
+
+                localStorage.setItem(key, 'false');
+
+                const { result } = renderHook(() => useLocalStorage(key, defaultValue));
+
+                expect(result.current[0]).toBe(false);
+                expect(JSON.parse(localStorage.getItem(key)!)).toBe(false);
+            });
         });
     });
 });


### PR DESCRIPTION
### Summary

This is a great utility hook, but I ran into some issues when storing booleans (specifically `false` with a `true` initial value).

Basically, when the local storage value is `false` (or more specifically, `"false"`) and an initial value of `true` is specified, the value returned by the `useLocalStorage` hook is `true`.

There are certain UI cases where one would want the default behavior to be `true` but to still remember the case where the user has toggled that behavior to a `false` state (like remembering if a slideout is opened or closed).

I've gotten around this by using numerical values, but it would be great if this hook supported the case where the local storage value is `false` while the default behavior is `true`.

### Reproducing the behavior

Here's a screenshot of the behavior

![image](https://user-images.githubusercontent.com/8136030/76631410-0bcfa700-6518-11ea-8b09-4ee7b75166b4.png)

Here's a link to the underlying demo: https://stackblitz.com/edit/local-storage-false-example

Basically, toggle the button until the local storage value is `false` and then reload the page.

### Discussion

I noticed that in a lot of places, the default value is only set / used if the parsed local storage value is falsy.

```javascript
tryParse(localStorage.getItem(key)!) || initialValue
```

From [the `Storage#getItem` MDN page](https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem) it seems like the existence of a key is determined by whether `null` is returned by `getItem`.

![image](https://user-images.githubusercontent.com/8136030/76631825-acbe6200-6518-11ea-9335-a2bd0f3823d5.png)

Maybe it would be more appropriate to check if `localStorage.getItem(key)` is `null` before falling back to the initial value?

I know this is a breaking change, which would necessitate a `v3.x.x` release, but it might ultimately lead to more expected behavior?