### PR TITLE
add storage class to handle gracefull degration

### DIFF
--- a/src/local-storage-events.ts
+++ b/src/local-storage-events.ts
@@ -1,3 +1,4 @@
+import { storage  } from './storage'
 interface KVP<K, V> {
     key: K,
     value: V
@@ -49,7 +50,7 @@ export function isTypeOfLocalStorageChanged<TValue>(evt: any): evt is LocalStora
  */
 export function writeStorage<TValue>(key: string, value: TValue) {
     try {
-        localStorage.setItem(key, typeof value === 'object' ? JSON.stringify(value) : `${value}`);
+        storage.setItem(key, typeof value === 'object' ? JSON.stringify(value) : `${value}`);
         window.dispatchEvent(new LocalStorageChanged({ key, value }));
     } catch (err) {
         if (err instanceof TypeError && err.message.includes('circular structure')) {
@@ -86,6 +87,6 @@ export function writeStorage<TValue>(key: string, value: TValue) {
  * @param {string} key The key of the item you wish to delete from localStorage.
  */
 export function deleteFromStorage(key: string) {
-    localStorage.removeItem(key);
+    storage.removeItem(key);
     window.dispatchEvent(new LocalStorageChanged({ key, value: null }))
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,64 @@
+/**
+ * Test if localStorage API is available
+ * From https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Feature-detecting_localStorage
+ * @returns {boolean}
+ */
+export function localStorageAvailable(): boolean {
+  try {
+    var x = '@rehooks/local-storage:' + new Date().toISOString();
+    localStorage.setItem(x, x);
+    localStorage.removeItem(x);
+    return true;
+  }
+  catch(e) {
+    return e instanceof DOMException && (
+      // everything except Firefox
+      e.code === 22 ||
+      // Firefox
+      e.code === 1014 ||
+      // test name field too, because code might not be present
+      // everything except Firefox
+      e.name === 'QuotaExceededError' ||
+      // Firefox
+      e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+      // acknowledge QuotaExceededError only if there's something already stored
+      (localStorage && localStorage.length !== 0);
+  }
+}
+
+
+/**
+ * Provides a proxy to localStorage, returning default return values
+ * if `localStorage` is not available
+ */
+export class ProxyStorage {
+  available: boolean
+
+  constructor() {
+    this.available = localStorageAvailable()
+  }
+
+  getItem(key: string): string | null {
+    if (this.available === true) {
+      return localStorage.getItem(key)
+    }
+    return null
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.available === true) {
+      return localStorage.setItem(key, value)
+    }
+    return undefined
+  }
+
+  removeItem(key: string): void {
+    if (this.available === true) {
+      return localStorage.removeItem(key)
+    }
+    return undefined
+  }
+}
+
+
+export const storage = new ProxyStorage()

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -27,38 +27,44 @@ export function localStorageAvailable(): boolean {
 }
 
 
-/**
- * Provides a proxy to localStorage, returning default return values
- * if `localStorage` is not available
- */
-export class ProxyStorage {
-  available: boolean
+interface IProxyStorage {
+  getItem(key: string): string | null
+  setItem(Key: string, value: string): void
+  removeItem(key: string): void
+}
 
-  constructor() {
-    this.available = localStorageAvailable()
-  }
-
+export class LocalStorageProxy implements IProxyStorage {
   getItem(key: string): string | null {
-    if (this.available === true) {
-      return localStorage.getItem(key)
-    }
-    return null
+    return localStorage.getItem(key)
   }
 
   setItem(key: string, value: string): void {
-    if (this.available === true) {
-      return localStorage.setItem(key, value)
-    }
-    return undefined
+    localStorage.setItem(key, value)
   }
 
   removeItem(key: string): void {
-    if (this.available === true) {
-      return localStorage.removeItem(key)
-    }
-    return undefined
+    localStorage.removeItem(key)
   }
 }
 
+export class MemoryStorageProxy implements IProxyStorage {
+  private _memoryStorage = new Map<string, string>()
 
-export const storage = new ProxyStorage()
+  getItem(key: string): string | null {
+    return this._memoryStorage.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    this._memoryStorage.set(key, value)
+  }
+
+  removeItem(key: string): void {
+    this._memoryStorage.delete(key)
+  }
+}
+
+const proxyStorageFrom = (isAvailable: boolean) => isAvailable
+  ? new LocalStorageProxy()
+  : new MemoryStorageProxy()
+
+export const storage = proxyStorageFrom(localStorageAvailable())

--- a/src/use-localstorage.ts
+++ b/src/use-localstorage.ts
@@ -5,7 +5,7 @@ import {
   isTypeOfLocalStorageChanged,
 } from './local-storage-events';
 import { storage  } from './storage'
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 
 /**
  * This exists for trying to serialize the value back to JSON.

--- a/src/use-localstorage.ts
+++ b/src/use-localstorage.ts
@@ -4,7 +4,8 @@ import {
   LocalStorageChanged,
   isTypeOfLocalStorageChanged,
 } from './local-storage-events';
-import { useEffect, useState, useCallback } from 'react';
+import { storage  } from './storage'
+import { useEffect, useState, useCallback, useRef } from 'react';
 
 /**
  * This exists for trying to serialize the value back to JSON.
@@ -53,9 +54,9 @@ export function useLocalStorage<TValue = string>(
   defaultValue: TValue | null = null,
 ) {
   const [localState, updateLocalState] = useState<TValue | null>(
-    localStorage.getItem(key) === null
+    storage.getItem(key) === null
       ? defaultValue
-      : tryParse(localStorage.getItem(key)!)
+      : tryParse(storage.getItem(key)!)
   );
 
   const onLocalStorageChange = (event: LocalStorageChanged<TValue> | StorageEvent) => {
@@ -83,7 +84,7 @@ export function useLocalStorage<TValue = string>(
 
     // Write default value to the local storage if there currently isn't any value there.
     // Don't however write a defaultValue that is null otherwise it'll trigger infinite updates.
-    if (localStorage.getItem(key) === null && defaultValue !== null) {
+    if (storage.getItem(key) === null && defaultValue !== null) {
       writeStorage(key, defaultValue);
     }
 

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -3,6 +3,8 @@ import { useLocalStorage, writeStorage, deleteFromStorage } from '../src';
 import { renderHook } from '@testing-library/react-hooks';
 import { render, fireEvent, act, cleanup } from '@testing-library/react';
 
+import { storage } from '../src/storage'
+
 
 afterEach(() => {
   cleanup();

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -1,0 +1,56 @@
+import { ProxyStorage } from '../src/storage'
+
+describe('ProxyStorage', () => {
+    describe('when localStorage is available', () => {
+        // check assumption localStorage is available in tests
+        window.localStorage.setItem('hi', 'hi')
+        expect(window.localStorage.getItem('hi')).toEqual('hi')
+
+        const storage = new ProxyStorage()
+
+        it('initiates ProxyStorage as available', () => {
+            expect(storage.available).toEqual(true)
+        })
+
+        it('calls localStorage.setItem', () => {
+            storage.setItem('key1', 'value2')
+            expect(localStorage.getItem('key1')).toEqual('value2')
+        })
+
+        it('calls localStorage.getItem', () => {
+            localStorage.setItem('key2', 'value1')
+            expect(storage.getItem('key2')).toEqual('value1')
+        })
+
+        it('calls localStorage.removeItem', () => {
+            localStorage.setItem('key3', 'value1')
+            expect(storage.removeItem('key3')).toEqual(undefined)
+            expect(localStorage.getItem('key3')).toEqual(null)
+        })
+    })
+
+    describe('when localStorage is not available', () => {
+        // check assumption localStorage is available in tests
+        window.localStorage.setItem('hi', 'hi')
+        expect(window.localStorage.getItem('hi')).toEqual('hi')
+
+        const storage = new ProxyStorage()
+        storage.available = false
+
+        it('returns default instead of calling localStorage.setItem', () => {
+            expect(storage.setItem('key4', 'value2')).toEqual(undefined)
+            expect(localStorage.getItem('key4')).toEqual(null)
+        })
+
+        it('returns default instead of calling localStorage.getItem', () => {
+            localStorage.setItem('key5', 'value1')
+            expect(storage.getItem('key5')).toEqual(null)
+        })
+
+        it('returns default instead of calling localStorage.getItem', () => {
+            localStorage.setItem('key6', 'value1')
+            expect(storage.removeItem('key6')).toEqual(undefined)
+            expect(localStorage.getItem('key6')).toEqual('value1')
+        })
+    })
+})

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -1,4 +1,4 @@
-import { ProxyStorage } from '../src/storage'
+import { MemoryStorageProxy, LocalStorageProxy } from '../src/storage'
 
 describe('ProxyStorage', () => {
     describe('when localStorage is available', () => {
@@ -6,11 +6,7 @@ describe('ProxyStorage', () => {
         window.localStorage.setItem('hi', 'hi')
         expect(window.localStorage.getItem('hi')).toEqual('hi')
 
-        const storage = new ProxyStorage()
-
-        it('initiates ProxyStorage as available', () => {
-            expect(storage.available).toEqual(true)
-        })
+        const storage = new LocalStorageProxy()
 
         it('calls localStorage.setItem', () => {
             storage.setItem('key1', 'value2')
@@ -34,8 +30,7 @@ describe('ProxyStorage', () => {
         window.localStorage.setItem('hi', 'hi')
         expect(window.localStorage.getItem('hi')).toEqual('hi')
 
-        const storage = new ProxyStorage()
-        storage.available = false
+        const storage = new MemoryStorageProxy()
 
         it('returns default instead of calling localStorage.setItem', () => {
             expect(storage.setItem('key4', 'value2')).toEqual(undefined)

--- a/test/use-localstorage.test.ts
+++ b/test/use-localstorage.test.ts
@@ -1,6 +1,8 @@
 import { useLocalStorage, deleteFromStorage } from '../src';
 import { renderHook, act } from '@testing-library/react-hooks';
 
+import { storage } from '../src/storage'
+
 describe('Module: use-localstorage', () => {
     describe('useLocalStorage', () => {
         it('is callable', () => {
@@ -130,5 +132,48 @@ describe('Module: use-localstorage', () => {
                 });
             });
         });
+
+        describe("when localStorage api is disabled", () => {
+            beforeAll(() => storage.available = false)
+
+            afterAll(() => storage.available = true)
+
+            it('should return default value', () => {
+
+                const key = 'car';
+                const defaultValue = 'beamer'
+
+                const { result } = renderHook(() => useLocalStorage(key, defaultValue))
+
+                expect(result.current[0]).toBe(defaultValue)
+            })
+
+            it('still tracks state in localStorage', () => {
+                const key = 'car';
+                const defaultValue = 'beamer'
+
+                const { result } = renderHook(() => useLocalStorage(key, defaultValue))
+
+                expect(result.current[0]).toBe(defaultValue)
+
+                act(() => result.current[1]('merc'))
+                expect(result.current[0]).toEqual('merc')
+                expect(localStorage.getItem('car')).toEqual(null)
+            })
+
+            it('defaults back to defaultValue in localState when deleted', () => {
+                const key = 'unavailableAPI';
+                const defaultValue = 'localStorage'
+
+                const { result } = renderHook(() => useLocalStorage(key, defaultValue))
+
+                expect(result.current[0]).toBe(defaultValue)
+
+                act(() => result.current[1]('webrtc'))
+                expect(result.current[0]).toEqual('webrtc')
+                act(() => deleteFromStorage('unavailableAPI'))
+                expect(result.current[0]).toEqual(defaultValue)
+            })
+        })
     });
 });

--- a/test/use-localstorage.test.ts
+++ b/test/use-localstorage.test.ts
@@ -1,137 +1,156 @@
 import { useLocalStorage, deleteFromStorage } from '../src';
 import { renderHook, act } from '@testing-library/react-hooks';
 
+jest.mock('../src/storage', () => ({
+  ...jest.requireActual('../src/storage'),
+  storage: jest.fn(),
+}));
+
+import { storage, LocalStorageProxy, MemoryStorageProxy  } from '../src/storage'
+
 describe('Module: use-localstorage', () => {
+
     describe('useLocalStorage', () => {
-        it('is callable', () => {
-            const { result } = renderHook(() => useLocalStorage('foo', 'bar'));
-            expect(result.current).toBeDefined();
-        });
+        describe('LocalStorage API enabled', () => {
+            beforeAll(() => {
+                // @ts-ignore
+                storage = new LocalStorageProxy()
+            })
 
-        it('accepts non-JSON strings', () => {
-            const key = 'name';
-            const defaultValue = 'bond';
-            localStorage.setItem(key, defaultValue);
+            it('is callable', () => {
+                const { result } = renderHook(() => useLocalStorage('foo', 'bar'));
+                expect(result.current).toBeDefined();
+            });
 
-            const { result } = renderHook(() => useLocalStorage(key));
+            it('accepts non-JSON strings', () => {
+                const key = 'name';
+                const defaultValue = 'bond';
+                localStorage.setItem(key, defaultValue);
 
-            expect(result.current[0]).toBe(defaultValue);
-        });
+                const { result } = renderHook(() => useLocalStorage(key));
 
-        it('returns a javascript object if it finds a JSON string', () => {
-            const key = '🛸🛸🛸🛸🛸';
-            const value = { _: 'a', 3: true, z: { y: [2] } };
-            localStorage.setItem(key, JSON.stringify(value));
+                expect(result.current[0]).toBe(defaultValue);
+            });
 
-            const { result } = renderHook(() => useLocalStorage(key));
+            it('returns a javascript object if it finds a JSON string', () => {
+                const key = '🛸🛸🛸🛸🛸';
+                const value = { _: 'a', 3: true, z: { y: [2] } };
+                localStorage.setItem(key, JSON.stringify(value));
 
-            expect(result.current[0]).toEqual(value);
-        });
+                const { result } = renderHook(() => useLocalStorage(key));
+
+                expect(result.current[0]).toEqual(value);
+            });
 
 
-        it('does not override existing data', () => {
-            const key = `dynamickey-` + Date.now();
-            const firstDefaultValue = Date.now();
+            it('does not override existing data', () => {
+                const key = `dynamickey-` + Date.now();
+                const firstDefaultValue = Date.now();
 
-            // first call of the hook
-            const { result } = renderHook(() => useLocalStorage(key, firstDefaultValue));
-            expect(result.current[0]).toBe(firstDefaultValue);
-            expect(parseInt(localStorage.getItem(key)!)).toBe(firstDefaultValue);
-            // second render. as the value already set, default value
-            // should not override existing value.
-            const { result: result2 } = renderHook(() => useLocalStorage(key, Date()));
+                // first call of the hook
+                const { result } = renderHook(() => useLocalStorage(key, firstDefaultValue));
+                expect(result.current[0]).toBe(firstDefaultValue);
+                expect(parseInt(localStorage.getItem(key)!)).toBe(firstDefaultValue);
+                // second render. as the value already set, default value
+                // should not override existing value.
+                const { result: result2 } = renderHook(() => useLocalStorage(key, Date()));
 
-            const [lastValue] = result2.current;
+                const [lastValue] = result2.current;
 
-            expect(lastValue).toEqual(firstDefaultValue);
-            expect(parseInt(localStorage.getItem(key)!)).toBe(firstDefaultValue);
-        });
+                expect(lastValue).toEqual(firstDefaultValue);
+                expect(parseInt(localStorage.getItem(key)!)).toBe(firstDefaultValue);
+            });
 
-        it('can have a numeric default value', () => {
-            const key = 'Numberwang';
-            const defaultValue = 42;
-            const { result } = renderHook(() => useLocalStorage(key, defaultValue));
-
-            expect(result.current[0]).toBe(defaultValue);
-            expect(parseInt(localStorage.getItem(key)!)).toBe(defaultValue);
-        });
-
-        it('can have a default value of 0', async () => {
-            const key = 'AmountOfMoneyInMyBankAccount';
-            const defaultValue = 0;
-            const { result } = renderHook(() => useLocalStorage(key, defaultValue));
-
-            expect(result.current[0]).toBe(defaultValue);
-            expect(localStorage.getItem(key)).toBe(`${defaultValue}`);
-        });
-
-        describe('when existing value is false', () => {
-            it('returns false value when the default value is true', () => {
-                const key = 'AmIFalse';
-                const defaultValue = true;
-
-                localStorage.setItem(key, 'false');
-
+            it('can have a numeric default value', () => {
+                const key = 'Numberwang';
+                const defaultValue = 42;
                 const { result } = renderHook(() => useLocalStorage(key, defaultValue));
 
-                expect(result.current[0]).toBe(false);
-                expect(JSON.parse(localStorage.getItem(key)!)).toBe(false);
+                expect(result.current[0]).toBe(defaultValue);
+                expect(parseInt(localStorage.getItem(key)!)).toBe(defaultValue);
             });
 
-            it('returns false value when default value is false', () => {
-                const key = 'AmIFalse';
-                const defaultValue = false;
-
-                localStorage.setItem(key, 'false');
-
+            it('can have a default value of 0', async () => {
+                const key = 'AmountOfMoneyInMyBankAccount';
+                const defaultValue = 0;
                 const { result } = renderHook(() => useLocalStorage(key, defaultValue));
 
-                expect(result.current[0]).toBe(false);
-                expect(JSON.parse(localStorage.getItem(key)!)).toBe(false);
+                expect(result.current[0]).toBe(defaultValue);
+                expect(localStorage.getItem(key)).toBe(`${defaultValue}`);
             });
-        });
 
-        describe('when a default value is given and deleteFromStorage is called', () => {
-            describe('current value', () => {
-                it('becomes the default value', async () => {
-                    const key = 'profile';
-                    const defaultValue = { firstName: 'Corona', lastName: 'Virus', url: 'https://iam.co/vid?q=19' };
-                    const newValue: typeof defaultValue = { firstName: 'Pro', lastName: 'Test', url: 'https://www.professionaltesting.com' };
-                    const { result } = renderHook(
-                        () => useLocalStorage(key, defaultValue)
-                    );
+            describe('when existing value is false', () => {
+                it('returns false value when the default value is true', () => {
+                    const key = 'AmIFalse';
+                    const defaultValue = true;
 
-                    expect(result.current[0]).toBe(defaultValue);
+                    localStorage.setItem(key, 'false');
 
-                    act(() => result.current[1](newValue));
-                    expect(result.current[0]).toBe(newValue);
-
-                    act(() => deleteFromStorage(key));
-                    expect(result.current[0]).toBe(defaultValue);
-                });
-            });
-            describe('the value in localStorage', () => {
-                it('is null', async () => {
-                    const key = '<<>>';
-                    const defaultValue = 'i';
-                    const newValue = 'o';
                     const { result } = renderHook(() => useLocalStorage(key, defaultValue));
-                    
-                    expect(result.current[0]).toBe(defaultValue);
-                    expect(localStorage.getItem(key)).toBe(defaultValue);
 
-                    act(() => result.current[1](newValue));
-                    expect(localStorage.getItem(key)).toBe(newValue);
-                    expect(result.current[0]).toBe(newValue);
+                    expect(result.current[0]).toBe(false);
+                    expect(JSON.parse(localStorage.getItem(key)!)).toBe(false);
+                });
 
-                    act(() => result.current[2]());
-                    expect(localStorage.getItem(key)).toBe(null);
-                    expect(result.current[0]).toBe(defaultValue);
+                it('returns false value when default value is false', () => {
+                    const key = 'AmIFalse';
+                    const defaultValue = false;
+
+                    localStorage.setItem(key, 'false');
+
+                    const { result } = renderHook(() => useLocalStorage(key, defaultValue));
+
+                    expect(result.current[0]).toBe(false);
+                    expect(JSON.parse(localStorage.getItem(key)!)).toBe(false);
                 });
             });
-        });
+
+            describe('when a default value is given and deleteFromStorage is called', () => {
+                describe('current value', () => {
+                    it('becomes the default value', async () => {
+                        const key = 'profile';
+                        const defaultValue = { firstName: 'Corona', lastName: 'Virus', url: 'https://iam.co/vid?q=19' };
+                        const newValue: typeof defaultValue = { firstName: 'Pro', lastName: 'Test', url: 'https://www.professionaltesting.com' };
+                        const { result } = renderHook(
+                            () => useLocalStorage(key, defaultValue)
+                        );
+
+                        expect(result.current[0]).toBe(defaultValue);
+
+                        act(() => result.current[1](newValue));
+                        expect(result.current[0]).toBe(newValue);
+
+                        act(() => deleteFromStorage(key));
+                        expect(result.current[0]).toBe(defaultValue);
+                    });
+                });
+                describe('the value in localStorage', () => {
+                    it('is null', async () => {
+                        const key = '<<>>';
+                        const defaultValue = 'i';
+                        const newValue = 'o';
+                        const { result } = renderHook(() => useLocalStorage(key, defaultValue));
+                        
+                        expect(result.current[0]).toBe(defaultValue);
+                        expect(localStorage.getItem(key)).toBe(defaultValue);
+
+                        act(() => result.current[1](newValue));
+                        expect(localStorage.getItem(key)).toBe(newValue);
+                        expect(result.current[0]).toBe(newValue);
+
+                        act(() => result.current[2]());
+                        expect(localStorage.getItem(key)).toBe(null);
+                        expect(result.current[0]).toBe(defaultValue);
+                    });
+                });
+            });
+        })
 
         describe("when localStorage api is disabled", () => {
+            beforeAll(() => {
+                // @ts-ignore
+                storage = new MemoryStorageProxy()
+            })
             it('should return default value', () => {
 
                 const key = 'car';

--- a/test/use-localstorage.test.ts
+++ b/test/use-localstorage.test.ts
@@ -1,8 +1,6 @@
 import { useLocalStorage, deleteFromStorage } from '../src';
 import { renderHook, act } from '@testing-library/react-hooks';
 
-import { storage } from '../src/storage'
-
 describe('Module: use-localstorage', () => {
     describe('useLocalStorage', () => {
         it('is callable', () => {
@@ -134,10 +132,6 @@ describe('Module: use-localstorage', () => {
         });
 
         describe("when localStorage api is disabled", () => {
-            beforeAll(() => storage.available = false)
-
-            afterAll(() => storage.available = true)
-
             it('should return default value', () => {
 
                 const key = 'car';


### PR DESCRIPTION
fix #60 

I've changed all calls to `localStorage` to go through `ProxyStorage`. This either forwards the calls to `localStorage` or returns the default return/empty return value. As calls to `localStorage` are synchronous thought it best to minimise the calls to test availability so this is only assessed on load. Let me know what you think of this approach.

Would be great to get some feedback on the tests. I initially tried to rely more on mocking to change the behaviour of Proxy/localStorage, but ran into a few problems. Don't have that much experience with jest mocking so if you see any way this could be done better would love to hear.

Also indentation seems to vary a bit between files, is there a certain preference you want me to follow? 