### PR TITLE
docs: fix typo in docs/classes/_local_storage_events_.localstoragechanged.html

### DIFF
--- a/docs/classes/_local_storage_events_.localstoragechanged.html
+++ b/docs/classes/_local_storage_events_.localstoragechanged.html
@@ -308,7 +308,7 @@
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
-							<p>Returns true if preventDefault() was invoked successfully to indicate cancelation, and false otherwise.</p>
+							<p>Returns true if preventDefault() was invoked successfully to indicate cancellation, and false otherwise.</p>
 						</div>
 					</div>
 				</section>


### PR DESCRIPTION
Hello,

This tiny PR will fix : 

- 1 typo in `docs/classes/_local_storage_events_.localstoragechanged.html`



Cheers! :robot: