### PR TITLE
Target es5 when compiling JS

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,6 @@
  * @type {jest.ProjectConfig}
  */
 module.exports = {
-
   roots: [
     '<rootDir>/test'
   ],
@@ -16,5 +15,10 @@ module.exports = {
     'jsx',
     'json',
     'node'
-  ]
+  ],
+  globals: {
+    'ts-jest': {
+      tsConfig: 'tsconfig.test.json'
+    }
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["dom", "es2015"],                 /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es6",
+  }
+}


### PR DESCRIPTION
This fixes #52 by targeting ES5 instead of ES6 when compiling. I've included the DOM and ES2015 libs so that types can be correctly checked.

I ran into issues with `ts-jest` failing tests with ES5 so I've setup a new `tsconfig.test.json` file which sets the target back to ES6 in the test environment.