### PR TITLE
fix global is not defined in browser

### DIFF
--- a/src/local-storage-events.ts
+++ b/src/local-storage-events.ts
@@ -11,7 +11,7 @@ export const LOCAL_STORAGE_CHANGE_EVENT_NAME = 'onLocalStorageChange';
       return;
     }
 
-    if (typeof global.window.CustomEvent === 'function') {
+    if (typeof window.CustomEvent === 'function') {
       return;
     }
 


### PR DESCRIPTION
with v2.4.4,  `ReferenceError: global is not defined` is happened. Check `isBrowser()` on Line:10 so this place is safe to use `window` 